### PR TITLE
Feat#3/avoid duplicate entries

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,10 +5,7 @@ const pipe 		= require( './utils/pipe' );
 const parsers = require( './parsers' );
 const wp 			= require( './utils/wordpress' )
 const profiles = require( './private/profiles' );
-
-const sentry = require( 'raven' ); 
-
-sentry.config( conf.sentry.dsn ).install();
+const sentry 	= require( './sentry' );
 
 let since = process.env.since || Math.ceil( ( Date.now() / 1000 ) - ( 60 * 60 ) );
 

--- a/index.js
+++ b/index.js
@@ -9,6 +9,15 @@ const sentry 	= require( './sentry' );
 
 let since = process.env.since || Math.ceil( ( Date.now() / 1000 ) - ( 60 * 60 ) );
 
+/**
+ * Use Sentry for Uncaught Exceptions
+ */
+process.on( 'uncaughtException', ( err ) => {
+
+    sentry.captureException( err );
+
+});
+
 console.log( 'Looking for updates since: ', since );
 
 // ( async () => {

--- a/sentry.js
+++ b/sentry.js
@@ -1,0 +1,6 @@
+const conf 		= require( './config/' );
+const sentry 	= require( 'raven' ); 
+
+sentry.config( conf.sentry.dsn ).install();
+
+module.exports = sentry;

--- a/utils/wordpress.js
+++ b/utils/wordpress.js
@@ -3,6 +3,7 @@
  */
 const conf 	= require( '../config' );
 const r2 	= require( 'r2' );
+const sentry = require( '../sentry' );
 
 const SITEID = '7369149';
 const API_BASE = `https://public-api.wordpress.com/rest/v1.1/sites/${SITEID}`;
@@ -61,6 +62,16 @@ function parse( post ){
 
 	} else {
 
+		if ( true === share_already_recorded( shares, post.buffer.service_link ) ) {
+
+			sentry.captureException(
+				new Error( `${post.buffer.service_link} already recorded for ${post.slug}` )
+			);
+
+			return null;
+
+		}
+
 		// update
 		shares[0].operation = 'update';
 		shares[0].value.push( [ post.buffer.service_link, post.buffer.due_at ] )
@@ -71,6 +82,25 @@ function parse( post ){
 		post_id : post.ID,
 		metadata : shares
 	};
+
+}
+
+/**
+ * Share Already Recorded
+ * Determine if the share URL already exists in the shares array
+ * @param array shares
+ * @param string share_url
+ * @return boolean
+ */
+function share_already_recorded( shares, share_url ) {
+
+	const test = shares[0].value.filter( ( sv ) => {
+
+		return post.buffer.service_link === sv[0];
+
+	});
+
+	return ( 0 !== test.length );
 
 }
 


### PR DESCRIPTION
### What Was Accomplished

- Made Sentry its own module instead of including it in the index file so it can be used in other places.
- Before updating an article's array of shares, check if that URL already exists.
- If its found...
  - Notify Sentry
  - Continue processing other articles

Resolves #3 