### PR TITLE
Get Post Slug and Tweet URL from Twitter API

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,9 +10,9 @@ const sleep = require( './utils/sleep' );
 
 /**
  * How far back to look for updates
- * Usually 10 minutes
+ * Usually 15 minutes
  */
-const interval = 10 * 60 * 1000;
+const interval = 15 * 60 * 1000;
 
 // now - interval
 let since;

--- a/parsers/facebook.js
+++ b/parsers/facebook.js
@@ -3,7 +3,6 @@
  */
 
 const url = require( 'url' );
-const r2 	= require( 'r2' );
 const redirect_follower = require( '../utils/redirect-follower' );
 const find_post_slug = require( '../utils/find-post-slug' );
 const profiles = require( '../private/profiles' );

--- a/parsers/twitter.js
+++ b/parsers/twitter.js
@@ -2,11 +2,11 @@
  * Parse WordPress post links from Twitter updates published through Buffer
  */
 
-const twitter = require( 'twitter-text' );
 const url 		= require( 'url' );
-const r2 			= require( 'r2' );
 const redirect_follower = require( '../utils/redirect-follower' );
 const find_post_slug = require( '../utils/find-post-slug' );
+const request = require( 'request-promise-any' );
+const conf 	= require( '../config' );
 
 /**
  * Main Function
@@ -16,21 +16,83 @@ const find_post_slug = require( '../utils/find-post-slug' );
 
 module.exports = async ( update ) => {
 
-	// Get URL from tweet
-		// if there's no URL, bail
+	let tweet, post_slug, service_link;
 
-	const urls = twitter.extractUrls( update.text );
+	try {
 
-	if ( 0 === urls.length ) {
-		throw new Error( `No URLs found in Twitter update: ${update.id}` );
+		tweet = await get_tweet( update.service_update_id );
+
+		post_slug = await get_post_slug_from_tweet( tweet );
+
+		service_link = get_service_link_from_tweet( tweet );
+
+	} catch( err ) {
+
+		throw new Error( `Error getting Twitter update: ${update.id}` );
+
 	}
 
-	// If twitter says it found a URL, make sure its real
-		// For example, collective.world is a URL, but r2 can't follow it
+	return Object.assign( {}, update, { post_slug, service_link } );
+
+}
+
+/**
+ * Get Tweet
+ * @param  {string} tweet_id
+ * @return {Object} tweet
+ */
+async function get_tweet( tweet_id ) {
+
+	let resp, tweet;
+
+	const options = {
+		method: 'GET',
+		headers:{
+			'Authorization' : `Bearer ${conf.twitter.auth_token}`
+		},
+		url: "https://api.twitter.com/1.1/statuses/show.json",
+		qs: {
+			id: tweet_id
+		}
+	};
 
 	try{
 
-		new url.URL( urls[0] );
+		resp = await request( options )
+
+		tweet = JSON.parse( resp );
+
+	} catch( err ) {
+
+		throw err;
+
+	}
+
+	return tweet;
+
+}
+
+/**
+ * Get Post Slug From Tweet
+ * @param  {Object} tweet
+ * @return {string}
+ */
+async function get_post_slug_from_tweet( tweet ) {
+
+	const urls = tweet.entities.urls;
+
+	if ( 0 === urls.length ) {
+		throw new Error( 'No URLs in Tweet.' );
+	}
+
+	const url_in_tweet = ( 'expanded_url' in urls[0] ) ? urls[0].expanded_url : urls[0].url;
+
+	// If twitter says it found a URL, make sure its real
+		// For example, collective.world is a URL, but request can't follow it
+
+	try{
+
+		new url.URL( url_in_tweet );
 
 	} catch( err ) {
 		throw err;
@@ -43,7 +105,7 @@ module.exports = async ( update ) => {
 
 	try{
 
-		link = await redirect_follower( urls[0] );
+		link = await redirect_follower( url_in_tweet );
 
 	} catch( err ) {
 		throw err;
@@ -64,6 +126,17 @@ module.exports = async ( update ) => {
 		throw err;
 	}
 
-	return Object.assign( {}, update, { post_slug } );
+	return post_slug;
+
+}
+
+/**
+ * [get_service_link_from_tweet description]
+ * @param  {Object}
+ * @return {string}
+ */
+function get_service_link_from_tweet( tweet ) {
+
+	return `https://www.twitter.com/${tweet.user.screen_name}/status/${tweet.id_str}`;
 
 }


### PR DESCRIPTION
### What Was Accomplished

- The Buffer API can no longer supply Tweet text and links to those tweets because of a Twitter API rule change.
- So now we take the ID of the tweet and go find it from the Twitter API instead.